### PR TITLE
improved axis label legibility

### DIFF
--- a/client/radar.coffee
+++ b/client/radar.coffee
@@ -122,7 +122,7 @@ window.plugins.radar =
         left: 0
 
       dimension = keys.length
-      ruleColor = "#CCC"
+      ruleColor = "#EEE"
 
       angle = (i) ->
         (i / dimension) * 2 * Math.PI
@@ -198,10 +198,13 @@ window.plugins.radar =
         .style("stroke", ruleColor)
         .style "fill", "none"
       lineAxes.append("svg:text")
-        .text((d,i) -> keys[i])
+        .text((d,i) -> keys[i][0..19])
+        .attr('x',5)
+        .attr('y',-5)
         .attr("text-anchor", "start")
         .style("stroke", ruleColor)
         .style("cursor", 'pointer')
+        .style("font-size","14px")
         .attr("transform", "rotate(180)")
         .on("click", (d,i) ->
           wiki.doInternalLink keys[i], $(div).parents('.page')


### PR DESCRIPTION
We improve axis label legibility by offsetting the text from the lines they label, enlarging slightly the text size, limiting the labels as drawn to 20 characters and choosing a lighter gray to compensate for the otherwise increase in visual mass.

![image](https://user-images.githubusercontent.com/12127/55291609-27887e80-5395-11e9-90a5-0e41785026cc.png)
